### PR TITLE
fix: get qrcode url

### DIFF
--- a/lagrange/client/base.py
+++ b/lagrange/client/base.py
@@ -246,7 +246,9 @@ class BaseClient:
 
         if not ret_code and tlvs[0x17]:
             self._sig.qrsig = qrsig
-            return tlvs[0x17], Reader(tlvs[209]).read_bytes_with_length("u16").decode()
+            urlreader = Reader(tlvs[209])
+            urlreader.read_u8()
+            return tlvs[0x17], urlreader.read_bytes_with_length("u8", False).decode()
 
         return ret_code
 


### PR DESCRIPTION
![image](https://github.com/LagrangeDev/lagrange-python/assets/109732988/f7660a0f-16a4-454c-b2ad-b30aba6c6e4a)
如图，这是tlv209的数据，第二个byte转成uint8刚好是链接的长度