### PR TITLE
feat & refactor: Support forward references in `ProtoStruct`

### DIFF
--- a/lagrange/utils/binary/protobuf/models.py
+++ b/lagrange/utils/binary/protobuf/models.py
@@ -176,7 +176,6 @@ class ProtoStruct:
     def _get_field_mapping(cls) -> Dict[int, Tuple[str, Type[_ProtoTypes]]]:  # Tag, (Name, Type)
         field_mapping: Dict[int, Tuple[str, Type[_ProtoTypes]]] = {}
         if cls._delay_anno_map:
-            print(f"WARNING: '{cls.__name__}' has delay annotations: {cls._delay_anno_map}")
             cls._resolve_annotations(cls)
         for name, (typ, field) in cls._anno_map.items():
             field_mapping[field.tag] = (name, typ)


### PR DESCRIPTION
Now you can **using forward references** in ProtoStruct class, like below:
```python
class OidbFriend(ProtoStruct):
    uid: str = proto_field(1)
    custom_group: Optional[int] = proto_field(2, default=None)
    uin: int = proto_field(3)
    additional: list["OidbFriendAdditional"] = proto_field(10001)


class OidbFriendAdditional(ProtoStruct):
    type: int = proto_field(1)
    layer1: "OidbFriendLayer1" = proto_field(2, default=None)


class OidbFriendProperty(ProtoStruct):
    code: Optional[int] = proto_field(1)
    value: Optional[str] = proto_field(2)


class OidbFriendLayer1(ProtoStruct):
    properties: Optional[list[OidbFriendProperty]] = proto_field(2, default=None)
```
